### PR TITLE
Fix `ScrollingText` bugs

### DIFF
--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -22,6 +22,8 @@ const Body = styled.div`
 const Container = styled.div<{ $isMobile?: boolean }>`
   display: flex;
   flex-wrap: wrap;
+  gap: 10px;
+  padding: 0px 10px 10px;
   justify-content: space-between;
   align-items: stretch;
   height: 100vh;

--- a/src/components/containers/Column.tsx
+++ b/src/components/containers/Column.tsx
@@ -1,12 +1,24 @@
 import styled from "styled-components";
+import { useIsMobile } from "../../hooks";
 
-export const Column = styled.div`
+export const ColumnStyled = styled.div`
   flex: 1;
-  margin: 10px;
   box-sizing: border-box;
   border-radius: 10px;
   padding: 4px;
   height: 100%;
   flex-direction: column;
+  justify-content: space-between;
   display: flex;
 `;
+
+interface Props {
+  children?: React.ReactNode;
+}
+
+const Column: React.FC<Props> = ({ children }) => {
+  const isMobile = useIsMobile();
+  return <ColumnStyled style={{ width: isMobile ? "100%" : "30%" }}>{children}</ColumnStyled>;
+};
+
+export default Column;

--- a/src/components/containers/index.ts
+++ b/src/components/containers/index.ts
@@ -1,4 +1,4 @@
-export * from "./Column";
+export { default as Column } from "./Column";
 export * from "./Region";
 export { default as Popper } from "./Popper";
 export { default as Casing } from "./Casing";

--- a/src/components/navbar/NavBar.tsx
+++ b/src/components/navbar/NavBar.tsx
@@ -23,7 +23,7 @@ interface Props {
 
 const NavBarStyled = styled.div`
   width: 100%;
-  height: 55px;
+  min-height: 50px;
   background-color: transparent;
   display: flex;
   align-items: center;

--- a/src/components/text/ScrollingText.tsx
+++ b/src/components/text/ScrollingText.tsx
@@ -8,19 +8,24 @@ interface Props {
 const ScrollContainer = styled.div`
   margin: 0px;
   overflow: hidden;
-  max-width: 28vw;
   white-space: nowrap;
 `;
 
 const ScrollingText: React.FC<Props> = ({ children }) => {
   const [translateTime, setTranslateTime] = useState(0);
   const [translateVal, setTranslateVal] = useState(0);
+  const [transitioning, setTransitioning] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const timeoutRef = useRef<number | null>(null);
 
   const transitionTimePerPixel = 0.01;
 
   const scrollForward = () => {
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+    }
     if (containerRef.current) {
+      setTransitioning(true);
       const boxWidth = containerRef.current.clientWidth;
       const textWidth = containerRef.current.children[0].scrollWidth;
       const translateVal = Math.min(boxWidth - textWidth, 0);
@@ -32,6 +37,12 @@ const ScrollingText: React.FC<Props> = ({ children }) => {
   const scrollBackward = () => {
     setTranslateTime(0.6);
     setTranslateVal(0);
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+    }
+    timeoutRef.current = window.setTimeout(() => {
+      setTransitioning(false);
+    }, 700);
   };
 
   return (
@@ -40,16 +51,15 @@ const ScrollingText: React.FC<Props> = ({ children }) => {
       onMouseEnter={() => scrollForward()}
       onMouseLeave={() => scrollBackward()}
     >
-      <span
+      <div
         style={{
           display: "inline-block",
-          transitionTimingFunction: "ease-in-out",
-          transitionDuration: `${translateTime}s`,
+          transition: transitioning ? `transform ${translateTime}s ease-in-out` : "none",
           transform: `translateX(${translateVal}px)`,
         }}
       >
         {children}
-      </span>
+      </div>
     </ScrollContainer>
   );
 };


### PR DESCRIPTION
Fix bug where text got cut off on different screen sizes before reaching the total width of its parent.

Fix bug where text took longer to dissapear than other elements when hiding mashup controls.

Closes #27 
Closes #22 